### PR TITLE
Make quaternionic arrays compatible with `np.copy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ Similarly, if you multiply two quaternionic arrays, their product will be comput
 quaternion multiplication, rather than element-wise multiplication of floats as numpy usually
 performs.
 
-| :warning: WARNING                                                                                |
-|:-------------------------------------------------------------------------------------------------|
-| Because of an unfortunate choice by the numpy developers, the `np.copy` function will not preserve the quaternionic nature of an array by default; the result will just be a plain array of floats.  You could pass the optional argument `subok=True`, as in `q3 = np.copy(q1, subok=True)`, but it's easier to just use the member function: `q3 = q1.copy()`. |
-
 
 ## Algebra
 

--- a/quaternionic/arrays.py
+++ b/quaternionic/arrays.py
@@ -108,6 +108,9 @@ def QuaternionicArray(jit=jit, dtype=float):
             output = super().__array_function__(func, types, args, kwargs)
             if func in [np.copy]:
                 output = output.view(type(self))
+            if func in [np.ones_like]:
+                # Want the last dimension to equal [1,0,0,0] not [1,1,1,1]
+                output.vector = 0
             return output
 
         def __array_ufunc__(self, ufunc, method, *args, **kwargs):

--- a/quaternionic/arrays.py
+++ b/quaternionic/arrays.py
@@ -104,6 +104,12 @@ def QuaternionicArray(jit=jit, dtype=float):
                     "arrays of individual components, and `q.vector` to return the \"vector\" part."
                 )
 
+        def __array_function__(self, func, types, args, kwargs):
+            output = super().__array_function__(func, types, args, kwargs)
+            if func in [np.copy]:
+                output = output.view(type(self))
+            return output
+
         def __array_ufunc__(self, ufunc, method, *args, **kwargs):
             from . import algebra_ufuncs as algebra
 


### PR DESCRIPTION
This is a small pull request to make `np.copy(q)` return a  quaternionic copy of the input array. This is to alleviate the warning in the README.

Before:
```python
In [1]: import numpy as np                                                                                                           

In [2]: import quaternionic                                                                                                          

In [3]: q = quaternionic.array([1.2, 2.3, 3.4, 4.5]); q                                                                              
Out[3]: quaternionic.array([1.2, 2.3, 3.4, 4.5])

In [4]: type(q)                                                                                                                      
Out[4]: quaternionic.arrays.QuaternionicArray.<locals>.QArray

In [5]: q2 = np.copy(q); q2                                                                                                          
Out[5]: array([1.2, 2.3, 3.4, 4.5])

In [6]: type(q2)                                                                                                                     
Out[6]: numpy.ndarray
```

After:
```python
In [1]: import numpy as np                                                                                                           

In [2]: import quaternionic                                                                                                          

In [3]: q = quaternionic.array([1.2, 2.3, 3.4, 4.5]); q                                                                              
Out[3]: quaternionic.array([1.2, 2.3, 3.4, 4.5])

In [4]: type(q)                                                                                                                      
Out[4]: quaternionic.arrays.QuaternionicArray.<locals>.QArray

In [5]: q2 = np.copy(q); q2                                                                                                          
Out[5]: quaternionic.array([1.2, 2.3, 3.4, 4.5])

In [6]: type(q2)                                                                                                                     
Out[6]: quaternionic.arrays.QuaternionicArray.<locals>.QArray
```