### PR TITLE
Support `np.ones_like()`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 

--- a/quaternionic/arrays.py
+++ b/quaternionic/arrays.py
@@ -104,6 +104,13 @@ def QuaternionicArray(jit=jit, dtype=float):
                     "arrays of individual components, and `q.vector` to return the \"vector\" part."
                 )
 
+        def __array_function__(self, func, types, args, kwargs):
+            output = super().__array_function__(func, types, args, kwargs)
+            if func in [np.ones_like]:
+                # Want the last dimension to equal [1,0,0,0] not [1,1,1,1]
+                output.vector = 0
+            return output
+
         def __array_ufunc__(self, ufunc, method, *args, **kwargs):
             from . import algebra_ufuncs as algebra
 

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -52,3 +52,7 @@ def test_str(array):
     assert str(q) == str(q.ndarray)
 
 
+def test_ones_like(Qs):
+    z = np.ones_like(Qs)
+    assert np.all(z.ndarray[:, 1:] == 0)
+    assert np.all(z.ndarray[:, 0] == 1)


### PR DESCRIPTION
I added the ability to override `np.ones_like()` to return `[1,0,0,0]` in the last dimension, as pointed out in issue #12. Also, discussed in #24.

Before:
```python
In [1]: import numpy as np                                                                                                              

In [2]: import quaternionic                                                                                                             

In [3]: q = quaternionic.array([[1.2, 2.3, 3.4, 4.5], [10.2, 20.3, 30.4, 40.5]]); q                                                     
Out[3]: 
quaternionic.array([[ 1.2,  2.3,  3.4,  4.5],
       [10.2, 20.3, 30.4, 40.5]])

In [4]: np.ones_like(q)                                                                                                                 
Out[4]: 
quaternionic.array([[1., 1., 1., 1.],
       [1., 1., 1., 1.]])
```

After:
```python
In [1]: import numpy as np                                                                                                              

In [2]: import quaternionic                                                                                                             

In [3]: q = quaternionic.array([[1.2, 2.3, 3.4, 4.5], [10.2, 20.3, 30.4, 40.5]]); q                                                     
Out[3]: 
quaternionic.array([[ 1.2,  2.3,  3.4,  4.5],
       [10.2, 20.3, 30.4, 40.5]])

In [4]: np.ones_like(q)                                                                                                                 
Out[4]: 
quaternionic.array([[1., 0., 0., 0.],
       [1., 0., 0., 0.]])
```