### PR TITLE
Update pyproject.toml: move black to tool.poetry.dev-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,13 @@ numpy = "^1.19"
 scipy = "^1.0"
 numba = {version = ">=0.55", markers = "implementation_name == 'cpython'"}
 mkdocs = {version = ">=1.1.2", optional = true, markers = "implementation_name == 'cpython'"}
-black = {version = ">=22.1", optional = true, markers = "implementation_name == 'cpython'"}
 mktheapidocs = {version = ">=0.2", optional = true, markers = "implementation_name == 'cpython'"}
 pymdown-extensions = {version = "^8", optional = true, markers = "implementation_name == 'cpython'"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0"
 pytest-cov = ">=2.10.1"
+black = {version = ">=22.1", optional = true, markers = "implementation_name == 'cpython'"}
 
 [tool.poetry.extras]
 mkdocs = ["mkdocs"]


### PR DESCRIPTION
I've not used poetry before, but this is causing issues in my downstream repo. Let me know if this looks correct, but I've moved black to `tool.poetry.dev-dependencies`