### PR TITLE
Implementation of conversion methods to / from euler angles in any sequence 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,0 @@
-../README.md


### PR DESCRIPTION
## What is implemented
This is a follow-up to what I had posted [here](https://github.com/moble/quaternionic/issues/36). 

After asking here if there was any interest in implementing some kind of general conversion, as the one existing in Scipy, I was told that the algorithm for this was overcomplicated and hard to maintain.

I agreed, but it led me to study a better algorithm and I ended up coming with something: I recently published an article about a direct formula for the conversion between a quaternion variable to Euler angles in any sequence, which can be read [here](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0276302) (Open Access).

Instead of first converting it to rotation matrices and then to angles, it converts directly to angles. Moreover, all of the complicated matrix multiplications on the previous algorithm are replaced by a simple permutation of the quaternion elements. 

Compared to either having 12 separate formulas (or 24, taking into account both intrinsic and extrinsic rotations) or using the well known quaternion-to-matrix-to-euler method (used for SciPy, for example), this has 3 main advantages: 

1. Numerically, it is up to 30 times faster than the previous quaternion-to-matrix-to-euler method (used for SciPy, for example).
2. It is a lot simpler to implement, debug and maintain than both methods.
3. It provides simple formulas that, I imagine, can be used for theorerical work.

Because of all of these advantages, since the publishing of this algorithm in November, it has already been merged into the main development branches of both [Scipy](https://github.com/scipy/scipy/pull/17392) and [Sympy](https://github.com/sympy/sympy/pull/24358).

Since `quaternionic` kinda inspired me to publish this paper, I thought I should try to contribute it here too :)

## Implementation details
In order to have consistency with the whole Python "ecosystem", I decided to use the same style of sequence definition as used in Scipy: uppercase for intrinsic rotations, lowercase for extrinsic rotations.

Since `to_euler` was defined with a `@property` decorator, in order to use the `seq` parameter I had to remove the decorator. This might have some implications for other functions, like `to_spherical_coordinates`.

## Reasoning
While I do agree that Euler angles are terrible to be used directly, I'd argue that most people using quaternionic might be well aware of these problems.

In my particular work, for example, everything I do is done using quaternions, but then at the end of the day I have to show the data in Euler angles in order to communicate with my coworkers.

I'd argue that this could be the case of many people, and it could be nice to have this implemented in quaternionic.

## What is missing
I'm not an expert on jit, so if you're interested in having this on the library I'd appreciate some help on the warnings given by `pytest` when jit-arrays are used, namely:
```
E   numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
E   Untyped global name '_is_intrinsic': Cannot determine Numba type of <class 'function'>
E   
E   File "../../../../../../../../home/evbernardes/.local/lib/python3.8/site-packages/quaternionic/converters.py", line 476:
E           def to_euler_angles(self, seq='ZYZ'):
E               <source elided>
E               # check if sequence is correctly formatted and get lowercase
E               intrinsic = _is_intrinsic(seq)
```